### PR TITLE
Adding Graphics.cma + Types of functions setup and draw

### DIFF
--- a/app/compiler.ml
+++ b/app/compiler.ml
@@ -17,7 +17,10 @@ let create_build_folder (buildPath: string): unit =
 let create_sketch_file (buildPath: string) (moduleName: string): unit =
   let chan = open_out (Printf.sprintf "%s/sketch.ml" buildPath) in
   output_string chan (Printf.sprintf "open %s\n" moduleName);
-  output_string chan "let _ = setup (); while(true) do draw (); done";
+  output_string chan "let _ = let start = setup () in \
+                      let rec draw_rec s = \
+                      draw_rec (draw s) in \
+                      draw_rec start";
   close_out chan
 
 let compile filePath =

--- a/app/compiler.ml
+++ b/app/compiler.ml
@@ -35,14 +35,14 @@ let compile filePath =
   create_build_folder buildPath;
 
   (* Compile the specific sketch *)
-  if (Sys.command (Printf.sprintf "ocamlfind ocamlc -package processingml -c -o %s/%s.cmo libPML.cma %s/%s.ml"
+  if (Sys.command (Printf.sprintf "ocamlfind ocamlc -package processingml -c -o %s/%s.cmo graphics.cma libPML.cma %s/%s.ml"
                          buildPath fileName filePath fileName)) <> 0 then raise CompilationException;
 
   (* Create a file containing call to main methods, and compile it *)
   create_sketch_file buildPath moduleName;
 
   (* Compile whole sketch *)
-  if (Sys.command (Printf.sprintf "ocamlfind ocamlc -package processingml -I %s -o %s/%s.exe libPML.cma %s/%s.cmo %s/sketch.ml"
+  if (Sys.command (Printf.sprintf "ocamlfind ocamlc -package processingml -I %s -o %s/%s.exe graphics.cma libPML.cma %s/%s.cmo %s/sketch.ml"
                          buildPath buildPath fileName buildPath fileName buildPath)) <> 0 then raise CompilationException;
 
   (* Creates symlink in the main folder *)

--- a/samples/first/first.ml
+++ b/samples/first/first.ml
@@ -2,6 +2,6 @@
 
 open LibPML
 
-let setup () = print_endline "setup"
+let setup () = print_endline "setup"; 0
 
-let draw () = Test.hello ()
+let draw i = print_int i; Test.hello (); (i+1)


### PR DESCRIPTION
This small PR adds two things:
1) Correction of the compilation error, by adding graphics.cma to the library used by the calls to ocamlc

2) Sketches can now have a "state" passed from `setup` to `draw`, and then from one iteration of `draw` to the next. This is in my opinion a more elegant and functional solution than having a bunch of global `ref` updated by the draw function at each iteration. It follows from these changes that `draw` and `setup` must have specific types : `setup: unit -> 'a` and `draw: 'a -> 'a` **with `'a` being the same for `setup` and `draw`**