### PR TITLE
2d shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An OCaml implementation of the Processing library
 ## Dependencies
 This project currently only works for Unix-like systems (Linux or MacOS), since it is heavily reliant on the `Unix` OCaml module.
 
-In order to build sketches, and to build this project, you'll need to have OCaml and [opam](https://opam.ocaml.org/) installed, as well as [dune](https://github.com/ocaml/dune), which you can install through `opam install dune`.
+In order to build sketches, and to build this project, you'll need to have OCaml (>= 4.07.0) and [opam](https://opam.ocaml.org/) installed, as well as [dune](https://github.com/ocaml/dune), which you can install through `opam install dune`.
 
 ## Usage
 * Install the the app and library in your current opam switch with `opam install .`

--- a/library/color.ml
+++ b/library/color.ml
@@ -31,20 +31,24 @@ let green c = int_of_char c.g
 let blue c = int_of_char c.b
 
 type color_state_t = {
-  mutable fill: color;
-  mutable stroke: color;
+  mutable fill: color option;
+  mutable stroke: color option;
 }
 
 let color_state = {
-  fill = color_of_rgb 0 0 0;
-  stroke = color_of_rgb 0 0 0;
+  fill = Some (color_of_rgb 0 0 0);
+  stroke = Some (color_of_rgb 0 0 0);
 }
 
-let fill c = color_state.fill<-c
+let fill c = color_state.fill<-(Some c)
+
+let no_fill () = color_state.fill<-None
 
 let current_fill () = color_state.fill
 
-let stroke c = color_state.stroke<-c
+let stroke c = color_state.stroke<-(Some c)
+
+let no_stroke () = color_state.stroke<-None
 
 let current_stroke () = color_state.stroke
 

--- a/library/color.mli
+++ b/library/color.mli
@@ -30,14 +30,20 @@ val blue: color -> int
 (** Sets the color used to fill shapes *)
 val fill: color -> unit
 
+(** Disables filling geometry *)
+val no_fill: unit -> unit
+
 (** Gets the color used to fill shapes *)
-val current_fill: unit -> color
+val current_fill: unit -> color option
 
 (** Sets the color used to draw lines and borders around shapes *)
 val stroke: color -> unit
 
+(** Disables stroking outlines *)
+val no_stroke: unit -> unit
+
 (** Gets the color used to draw lines and borders around shapes *)
-val current_stroke: unit -> color
+val current_stroke: unit -> color option
 
 (** Draws a background of the given color *)
 val background: color -> unit

--- a/library/shape.ml
+++ b/library/shape.ml
@@ -6,6 +6,14 @@
 (*                                                                            *)
 (******************************************************************************)
 
+let arc x y w h start stop =
+  let degree_of_radian (a:float):int = int_of_float (a *. 180. /. Float.pi) in
+  let y = Env.height () - (y+1) in
+  Graphics.set_color (Color.int_of_color (Color.current_fill ()));
+  Graphics.fill_arc x y (w/2) (h/2) (degree_of_radian (-.start)) (degree_of_radian (-.stop));
+  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
+  Graphics.draw_arc x y (w/2) (h/2) (degree_of_radian (-.start)) (degree_of_radian (-.stop))
+
 let ellipse x y w h =
   let y = Env.height () - (y+1) in
   Graphics.set_color (Color.int_of_color (Color.current_fill ()));
@@ -17,6 +25,11 @@ let line x1 y1 x2 y2 =
   let y1 = Env.height () - (y1+1) and y2 = Env.height () - (y2+1) in
   Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
   Graphics.draw_segments [|(x1,y1,x2,y2)|]
+
+let point x y =
+  let y = Env.height () - (y+1) in
+  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
+  Graphics.plot x y
 
 let quad x1 y1 x2 y2 x3 y3 x4 y4 =
   let y1 = Env.height () - (y1+1) and y2 = Env.height () - (y2+1)

--- a/library/shape.ml
+++ b/library/shape.ml
@@ -11,49 +11,81 @@ open Graphics
 let arc x y w h start stop =
   let degree_of_radian (a:float):int = int_of_float (a *. 180. /. Float.pi) in
   let y = Env.height () - (y+1) in
-  set_color (Color.int_of_color (Color.current_fill ()));
-  fill_arc x y (w/2) (h/2) (degree_of_radian (-.start)) (degree_of_radian (-.stop));
-  set_color (Color.int_of_color (Color.current_stroke ()));
-  draw_arc x y (w/2) (h/2) (degree_of_radian (-.start)) (degree_of_radian (-.stop))
+  (match (Color.current_fill ()) with
+   | Some c ->
+       set_color (Color.int_of_color c);
+       fill_arc x y (w/2) (h/2) (degree_of_radian (-.start)) (degree_of_radian (-.stop))
+   | None -> ());
+  (match (Color.current_stroke ()) with
+   | Some c ->
+     set_color (Color.int_of_color c);
+     draw_arc x y (w/2) (h/2) (degree_of_radian (-.start)) (degree_of_radian (-.stop))
+   | None -> ())
 
 let ellipse x y w h =
   let y = Env.height () - (y+1) in
-  set_color (Color.int_of_color (Color.current_fill ()));
-  fill_ellipse x y (w/2) (h/2);
-  set_color (Color.int_of_color (Color.current_stroke ()));
-  draw_ellipse x y (w/2) (h/2)
+  (match (Color.current_fill ()) with
+   | Some c -> set_color (Color.int_of_color c);
+     fill_ellipse x y (w/2) (h/2);
+   | None -> ());
+  (match (Color.current_stroke ()) with
+   | Some c ->
+     set_color (Color.int_of_color c);
+     draw_ellipse x y (w/2) (h/2)
+   | None -> ())
 
 let line x1 y1 x2 y2 =
   let y1 = Env.height () - (y1+1) and y2 = Env.height () - (y2+1) in
-  set_color (Color.int_of_color (Color.current_stroke ()));
-  draw_segments [|(x1,y1,x2,y2)|]
+  match (Color.current_stroke ()) with
+  | Some c ->
+    set_color (Color.int_of_color c);
+    draw_segments [|(x1,y1,x2,y2)|]
+  | None -> ()
 
 let point x y =
   let y = Env.height () - (y+1) in
-  set_color (Color.int_of_color (Color.current_stroke ()));
-  plot x y
+  match (Color.current_stroke ()) with
+  | Some c ->
+    set_color (Color.int_of_color c);
+    plot x y
+  | None -> ()
 
 let quad x1 y1 x2 y2 x3 y3 x4 y4 =
   let y1 = Env.height () - (y1+1) and y2 = Env.height () - (y2+1)
   and y3 = Env.height () - (y3+1) and y4 = Env.height () - (y4+1) in
   let coords = [|(x1,y1);(x2,y2);(x3,y3);(x4,y4)|] in
-  set_color (Color.int_of_color (Color.current_fill ()));
-  fill_poly coords;
-  set_color (Color.int_of_color (Color.current_stroke ()));
-  draw_poly coords
+  (match (Color.current_fill ()) with
+   | Some c -> set_color (Color.int_of_color c);
+     fill_poly coords
+   | None -> ());
+  (match (Color.current_stroke ()) with
+   | Some c ->
+     set_color (Color.int_of_color c);
+     draw_poly coords
+   | None -> ())
 
 let rect x y w h =
   let y = Env.height () - (y+1) - h in
-  set_color (Color.int_of_color (Color.current_fill ()));
-  fill_rect x y w h;
-  set_color (Color.int_of_color (Color.current_stroke ()));
-  draw_rect x y w h
+  (match (Color.current_fill ()) with
+   | Some c -> set_color (Color.int_of_color c);
+     fill_rect x y w h;
+   | None -> ());
+  (match (Color.current_stroke ()) with
+   | Some c ->
+     set_color (Color.int_of_color c);
+     draw_rect x y w h
+   | None -> ())
 
 let triangle x1 y1 x2 y2 x3 y3 =
   let y1 = Env.height () - (y1+1) and y2 = Env.height () - (y2+1)
   and y3 = Env.height () - (y3+1) in
   let coords = [|(x1,y1);(x2,y2);(x3,y3)|] in
-  set_color (Color.int_of_color (Color.current_fill ()));
-  fill_poly coords;
-  set_color (Color.int_of_color (Color.current_stroke ()));
-  draw_poly coords
+  (match (Color.current_fill ()) with
+   | Some c -> set_color (Color.int_of_color c);
+     fill_poly coords
+   | None -> ());
+  (match (Color.current_stroke ()) with
+   | Some c ->
+     set_color (Color.int_of_color c);
+     draw_poly coords
+   | None -> ())

--- a/library/shape.ml
+++ b/library/shape.ml
@@ -6,6 +6,27 @@
 (*                                                                            *)
 (******************************************************************************)
 
+let ellipse x y w h =
+  let y = Env.height () - (y+1) in
+  Graphics.set_color (Color.int_of_color (Color.current_fill ()));
+  Graphics.fill_ellipse x y (w/2) (h/2);
+  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
+  Graphics.draw_ellipse x y (w/2) (h/2)
+
+let line x1 y1 x2 y2 =
+  let y1 = Env.height () - (y1+1) and y2 = Env.height () - (y2+1) in
+  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
+  Graphics.draw_segments [|(x1,y1,x2,y2)|]
+
+let quad x1 y1 x2 y2 x3 y3 x4 y4 =
+  let y1 = Env.height () - (y1+1) and y2 = Env.height () - (y2+1)
+  and y3 = Env.height () - (y3+1) and y4 = Env.height () - (y4+1) in
+  let coords = [|(x1,y1);(x2,y2);(x3,y3);(x4,y4)|] in
+  Graphics.set_color (Color.int_of_color (Color.current_fill ()));
+  Graphics.fill_poly coords;
+  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
+  Graphics.draw_poly coords
+
 let rect x y w h =
   let y = Env.height () - (y+1) - h in
   Graphics.set_color (Color.int_of_color (Color.current_fill ()));
@@ -13,9 +34,11 @@ let rect x y w h =
   Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
   Graphics.draw_rect x y w h
 
-let ellipse x y w h =
-  let y = Env.height () - (y+1) in
+let triangle x1 y1 x2 y2 x3 y3 =
+  let y1 = Env.height () - (y1+1) and y2 = Env.height () - (y2+1)
+  and y3 = Env.height () - (y3+1) in
+  let coords = [|(x1,y1);(x2,y2);(x3,y3)|] in
   Graphics.set_color (Color.int_of_color (Color.current_fill ()));
-  Graphics.fill_ellipse x y (w/2) (h/2);
+  Graphics.fill_poly coords;
   Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
-  Graphics.draw_ellipse x y (w/2) (h/2)
+  Graphics.draw_poly coords

--- a/library/shape.ml
+++ b/library/shape.ml
@@ -9,5 +9,13 @@
 let rect x y w h =
   let y = Env.height () - (y+1) - h in
   Graphics.set_color (Color.int_of_color (Color.current_fill ()));
-  Graphics.fill_rect (x+1) (y+1) (w-2) (h-2);
-  Graphics.set_color (Color.int_of_color (Color.current_stroke ())); Graphics.draw_rect x y w h
+  Graphics.fill_rect x y w h;
+  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
+  Graphics.draw_rect x y w h
+
+let ellipse x y w h =
+  let y = Env.height () - (y+1) in
+  Graphics.set_color (Color.int_of_color (Color.current_fill ()));
+  Graphics.fill_ellipse x y (w/2) (h/2);
+  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
+  Graphics.draw_ellipse x y (w/2) (h/2)

--- a/library/shape.ml
+++ b/library/shape.ml
@@ -6,52 +6,54 @@
 (*                                                                            *)
 (******************************************************************************)
 
+open Graphics
+
 let arc x y w h start stop =
   let degree_of_radian (a:float):int = int_of_float (a *. 180. /. Float.pi) in
   let y = Env.height () - (y+1) in
-  Graphics.set_color (Color.int_of_color (Color.current_fill ()));
-  Graphics.fill_arc x y (w/2) (h/2) (degree_of_radian (-.start)) (degree_of_radian (-.stop));
-  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
-  Graphics.draw_arc x y (w/2) (h/2) (degree_of_radian (-.start)) (degree_of_radian (-.stop))
+  set_color (Color.int_of_color (Color.current_fill ()));
+  fill_arc x y (w/2) (h/2) (degree_of_radian (-.start)) (degree_of_radian (-.stop));
+  set_color (Color.int_of_color (Color.current_stroke ()));
+  draw_arc x y (w/2) (h/2) (degree_of_radian (-.start)) (degree_of_radian (-.stop))
 
 let ellipse x y w h =
   let y = Env.height () - (y+1) in
-  Graphics.set_color (Color.int_of_color (Color.current_fill ()));
-  Graphics.fill_ellipse x y (w/2) (h/2);
-  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
-  Graphics.draw_ellipse x y (w/2) (h/2)
+  set_color (Color.int_of_color (Color.current_fill ()));
+  fill_ellipse x y (w/2) (h/2);
+  set_color (Color.int_of_color (Color.current_stroke ()));
+  draw_ellipse x y (w/2) (h/2)
 
 let line x1 y1 x2 y2 =
   let y1 = Env.height () - (y1+1) and y2 = Env.height () - (y2+1) in
-  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
-  Graphics.draw_segments [|(x1,y1,x2,y2)|]
+  set_color (Color.int_of_color (Color.current_stroke ()));
+  draw_segments [|(x1,y1,x2,y2)|]
 
 let point x y =
   let y = Env.height () - (y+1) in
-  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
-  Graphics.plot x y
+  set_color (Color.int_of_color (Color.current_stroke ()));
+  plot x y
 
 let quad x1 y1 x2 y2 x3 y3 x4 y4 =
   let y1 = Env.height () - (y1+1) and y2 = Env.height () - (y2+1)
   and y3 = Env.height () - (y3+1) and y4 = Env.height () - (y4+1) in
   let coords = [|(x1,y1);(x2,y2);(x3,y3);(x4,y4)|] in
-  Graphics.set_color (Color.int_of_color (Color.current_fill ()));
-  Graphics.fill_poly coords;
-  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
-  Graphics.draw_poly coords
+  set_color (Color.int_of_color (Color.current_fill ()));
+  fill_poly coords;
+  set_color (Color.int_of_color (Color.current_stroke ()));
+  draw_poly coords
 
 let rect x y w h =
   let y = Env.height () - (y+1) - h in
-  Graphics.set_color (Color.int_of_color (Color.current_fill ()));
-  Graphics.fill_rect x y w h;
-  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
-  Graphics.draw_rect x y w h
+  set_color (Color.int_of_color (Color.current_fill ()));
+  fill_rect x y w h;
+  set_color (Color.int_of_color (Color.current_stroke ()));
+  draw_rect x y w h
 
 let triangle x1 y1 x2 y2 x3 y3 =
   let y1 = Env.height () - (y1+1) and y2 = Env.height () - (y2+1)
   and y3 = Env.height () - (y3+1) in
   let coords = [|(x1,y1);(x2,y2);(x3,y3)|] in
-  Graphics.set_color (Color.int_of_color (Color.current_fill ()));
-  Graphics.fill_poly coords;
-  Graphics.set_color (Color.int_of_color (Color.current_stroke ()));
-  Graphics.draw_poly coords
+  set_color (Color.int_of_color (Color.current_fill ()));
+  fill_poly coords;
+  set_color (Color.int_of_color (Color.current_stroke ()));
+  draw_poly coords

--- a/library/shape.mli
+++ b/library/shape.mli
@@ -10,3 +10,6 @@
 
 (** Draws a rectangle to the screen *)
 val rect: int -> int -> int -> int -> unit
+
+(** Draws an ellipse to the screen *)
+val ellipse: int -> int -> int -> int -> unit

--- a/library/shape.mli
+++ b/library/shape.mli
@@ -8,8 +8,17 @@
 
 (** Drawing shapes *)
 
+(** Draws an ellipse to the screen *)
+val ellipse: int -> int -> int -> int -> unit
+
+(** Draws a line to the screen *)
+val line: int -> int -> int -> int -> unit
+
+(** Draws a quadrilateral (4-sided polygon) to the screen *)
+val quad: int -> int -> int -> int -> int -> int -> int -> int -> unit
+
 (** Draws a rectangle to the screen *)
 val rect: int -> int -> int -> int -> unit
 
-(** Draws an ellipse to the screen *)
-val ellipse: int -> int -> int -> int -> unit
+(** Draws a triangle (3-sided polygon) to the screen *)
+val triangle: int -> int -> int -> int -> int -> int -> unit

--- a/library/shape.mli
+++ b/library/shape.mli
@@ -8,11 +8,17 @@
 
 (** Drawing shapes *)
 
+(** Draws an arc to the screen *)
+val arc: int -> int -> int -> int -> float -> float -> unit
+
 (** Draws an ellipse to the screen *)
 val ellipse: int -> int -> int -> int -> unit
 
 (** Draws a line to the screen *)
 val line: int -> int -> int -> int -> unit
+
+(** Draws a point to the screen *)
+val point: int -> int -> unit
 
 (** Draws a quadrilateral (4-sided polygon) to the screen *)
 val quad: int -> int -> int -> int -> int -> int -> int -> int -> unit

--- a/samples/shapes/shapes.ml
+++ b/samples/shapes/shapes.ml
@@ -18,4 +18,10 @@ let draw () =
   line 85 20 85 75;
   stroke (color_of_rgb 0 0 0);
   quad 338 331 386 320 369 363 330 376;
-  triangle 430 175 458 120 486 175
+  triangle 430 175 458 120 486 175;
+  point 360 200; (* Somewhat at the center *)
+
+  arc 500 250 50 50 0. (Float.pi/.2.);
+  arc 500 250 60 60 (Float.pi/.2.) Float.pi;
+  arc 500 250 70 70 Float.pi (Float.pi*.5./.4.);
+  arc 500 250 80 80 (Float.pi*.5./.4.) (Float.pi*.2.)

--- a/samples/shapes/shapes.ml
+++ b/samples/shapes/shapes.ml
@@ -12,4 +12,10 @@ let setup () =
 let draw () =
   background (color_of_rgb 127 127 127);
   rect 60 120 50 60;
-  ellipse 300 100 160 100
+  ellipse 300 100 160 100;
+  line 30 20 85 20;
+  stroke (color_of_rgb 255 255 255);
+  line 85 20 85 75;
+  stroke (color_of_rgb 0 0 0);
+  quad 338 331 386 320 369 363 330 376;
+  triangle 430 175 458 120 486 175

--- a/samples/shapes/shapes.ml
+++ b/samples/shapes/shapes.ml
@@ -5,12 +5,12 @@ open Color
 open Shape
 
 let setup () =
-  Env.size 720 400;
-  stroke (color_of_rgb 0 0 0);
-  fill (color_of_rgb 255 255 255)
+  Env.size 720 400
 
 let draw () =
   background (color_of_rgb 127 127 127);
+  stroke (color_of_rgb 0 0 0);
+  fill (color_of_rgb 255 255 255);
   rect 60 120 50 60;
   ellipse 300 100 160 100;
   line 30 20 85 20;
@@ -22,6 +22,7 @@ let draw () =
   point 360 200; (* Somewhat at the center *)
 
   arc 500 250 50 50 0. (Float.pi/.2.);
+  no_fill ();
   arc 500 250 60 60 (Float.pi/.2.) Float.pi;
   arc 500 250 70 70 Float.pi (Float.pi*.5./.4.);
   arc 500 250 80 80 (Float.pi*.5./.4.) (Float.pi*.2.)

--- a/samples/shapes/shapes.ml
+++ b/samples/shapes/shapes.ml
@@ -11,4 +11,5 @@ let setup () =
 
 let draw () =
   background (color_of_rgb 127 127 127);
-  rect 10 20 50 60;
+  rect 60 120 50 60;
+  ellipse 300 100 160 100

--- a/samples/shapes/shapes.ml
+++ b/samples/shapes/shapes.ml
@@ -1,0 +1,14 @@
+(* Sketch demonstrating drawing of shapes *)
+
+open LibPML
+open Color
+open Shape
+
+let setup () =
+  Env.size 720 400;
+  stroke (color_of_rgb 0 0 0);
+  fill (color_of_rgb 255 255 255)
+
+let draw () =
+  background (color_of_rgb 127 127 127);
+  rect 10 20 50 60;


### PR DESCRIPTION
I added primitives necessary to draw basic, predefined 2d shapes :
* point
* line
* rectangle
* ellipse
* quadrilateral
* triangle
* arc

All of these are available throught the `Shape` module.
I also upped the minimum OCaml required (through README) version to 4.07 (latest version as of writing) to be able to use the new `Float` module, and in particular it's `pi` constant.